### PR TITLE
Upgraded plugin to work with Grails 2.3.2 > *

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,4 @@
 #Grails Metadata file
 #Tue Jan 17 09:13:30 CST 2012
-app.grails.version=2.0.0
+app.grails.version=2.3.2
 app.name=multi-datasource-support
-plugins.svn=1.0.1

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,15 +27,11 @@ grails.project.dependency.resolution = {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
 
         // runtime 'mysql:mysql-connector-java:5.1.5'
-        compile("org.spockframework:spock-grails-support:0.6-groovy-1.8-SNAPSHOT")
     }
 
     plugins {
-        build(":tomcat:$grailsVersion",
-              ":release:1.0.0") {
-            export = false
-        }
-        test(":spock:0.6-SNAPSHOT") {
+        build(":tomcat:7.0.54",
+              ":release:3.0.1") {
             export = false
         }
     }

--- a/test/projects/test-project/application.properties
+++ b/test/projects/test-project/application.properties
@@ -1,7 +1,6 @@
 #Grails Metadata file
 #Sat Jan 28 09:09:48 CST 2012
-app.grails.version=2.0.0
+app.grails.version=2.3.2
 app.name=test-project
 app.servlet.version=2.5
 app.version=0.1
-plugins.svn=1.0.0.M1

--- a/test/projects/test-project/grails-app/conf/BuildConfig.groovy
+++ b/test/projects/test-project/grails-app/conf/BuildConfig.groovy
@@ -37,13 +37,11 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        runtime ":hibernate:$grailsVersion"
+        runtime ":hibernate:3.6.10.18"
         runtime ":jquery:1.7.1"
         runtime ":resources:1.1.5"
 
-        build ":tomcat:$grailsVersion"
-
-        compile ":spock:0.6-SNAPSHOT"
+        build ":tomcat:7.0.54"
     }
 }
 

--- a/test/projects/test-project/test/integration/testproject/RelationTests.groovy
+++ b/test/projects/test-project/test/integration/testproject/RelationTests.groovy
@@ -4,27 +4,22 @@ import spock.lang.Specification
 
 class RelationTests extends Specification {
 
-    public void testDefaultDataSource() {
+    public void "test default datasource"() {
         setup:
-
             Foo foo = new Foo(foo: "foo1")
             foo.save()
 
             Bar bar = new Bar(bar: "bar1")
             bar.save()
-
         when:
-
             foo.setBar(bar)
-
         then:
 
             foo.getBar() == bar
     }
 
-    public void testIsDatasourceAware() {
+    public void "test is datasource aware"() {
         setup:
-
             Bar bar1 = new Bar(bar: "bar1")
             bar1.save()
 
@@ -33,13 +28,9 @@ class RelationTests extends Specification {
 
             FooLookup fooLookup = new FooLookup(foo: "fooLookup")
             fooLookup.save()
-
         when:
-
             fooLookup.setBar(bar2)
-
         then:
-
             bar2.id
             Bar.lookup.get(bar2.id) == bar2
             Bar.get(bar2.id) != bar2

--- a/test/projects/test-project/test/integration/testproject/RelationTests.groovy
+++ b/test/projects/test-project/test/integration/testproject/RelationTests.groovy
@@ -1,51 +1,52 @@
 package testproject
 
-import org.junit.Before
-import org.junit.Test
+import spock.lang.Specification
 
-class RelationTests extends GroovyTestCase {
+class RelationTests extends Specification {
 
-    Foo foo
-    FooLookup fooLookup
-    Bar bar
-
-    @Before
-    public void setUp() {
-        bar = new Bar(bar: "bar1")
-        assert bar.validate()
-        assert bar.save()
-        fooLookup = new FooLookup(foo: "fooLookup")
-        assert fooLookup.validate()
-        assert fooLookup.save()
-        foo = new Foo(foo: "foo1")
-        assert foo.validate()
-        assert foo.save()
-    }
-
-    @Test
     public void testDefaultDataSource() {
+        setup:
 
-        foo.setBar(bar)
+            Foo foo = new Foo(foo: "foo1")
+            foo.save()
 
-        assert foo.getBar() == bar
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
+
+        when:
+
+            foo.setBar(bar)
+
+        then:
+
+            foo.getBar() == bar
     }
 
-    @Test
     public void testIsDatasourceAware() {
-        Bar bar2 = new Bar(bar: "bar2")
-        assert bar2.validate()
-        assert bar2.lookup.save()
+        setup:
 
-        assert bar2.id
-        assert Bar.lookup.count() == 1
-        assert Bar.count() == 1
-        assert Bar.lookup.get(bar2.id) == bar2
-        assert Bar.get(bar2.id) != bar2
-        
-        fooLookup.setBar(bar2)
-        
-        assert fooLookup.barId == bar2.id
-        assert fooLookup.getBar() == Bar.lookup.get(bar2.id)
-        assert fooLookup.getBar() == bar2
+            Bar bar1 = new Bar(bar: "bar1")
+            bar1.save()
+
+            Bar bar2 = new Bar(bar: "bar2")
+            bar2.lookup.save()
+
+            FooLookup fooLookup = new FooLookup(foo: "fooLookup")
+            fooLookup.save()
+
+        when:
+
+            fooLookup.setBar(bar2)
+
+        then:
+
+            bar2.id
+            Bar.lookup.get(bar2.id) == bar2
+            Bar.get(bar2.id) != bar2
+            Bar.lookup.count() == 1
+            Bar.count() == 1
+            fooLookup.barId == bar2.id
+            fooLookup.getBar() == Bar.lookup.get(bar2.id)
+            fooLookup.getBar() == bar2
     }
 }

--- a/test/projects/test-project/test/unit/testproject/RelationUnitTests.groovy
+++ b/test/projects/test-project/test/unit/testproject/RelationUnitTests.groovy
@@ -1,138 +1,128 @@
 package testproject
 
-import grails.test.mixin.TestFor
+import spock.lang.Specification
+import spock.lang.Shared
 import grails.test.mixin.Mock
-import org.junit.Before
-import org.junit.Test
-import grails.test.mixin.support.GrailsUnitTestMixin
-import org.junit.Ignore
 
-@Mixin(GrailsUnitTestMixin)
 @Mock([Foo, Bar, Alpha, Beta])
-class RelationUnitTests {
-    
-    Foo foo
-    Bar bar
-    
-    @Before
-    public void setUp() {
-        bar = new Bar(bar: "bar1")
-        assert bar.validate()
-        assert bar.save()
-        foo = new Foo(foo: "foo1")
-        assert foo.validate()
-        assert foo.save()
-    }
-    
-    @Test
-    public void testGetter() {
-        assert foo
-        assert bar
-        assert !(foo.barId)
-        assert bar.id
-        
-        foo.barId = bar.id
-        
-        assert Bar.get(bar.id) == foo.getBar()
-    }
-    
-    @Test
-    public void testSetter() {
-        assert foo
-        assert bar
-        assert !(foo.barId)
-        assert bar.id
+class RelationUnitTests extends Specification {
 
-        assert bar.getId()
+    void "test getter"() {
+        given:
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
 
-        foo.setBar(bar)
-
-        assert foo.barId == bar.id
-        assert foo.getBar() == bar
-    }
-    
-    @Test
-    public void testSetterUnSavedArg() {
-        Bar bar2 = new Bar(bar: "bar2")
-        assert !(foo.barId)
-        
-        foo.setBar(bar2)
-        
-        assert !(foo.barId)
-        assert !(foo.getBar())
-        
-        foo.setBar(bar)
-        assert foo.barId
-        assert foo.getBar() == bar
-        
-        foo.setBar(bar2)
-        assert foo.barId
-        assert foo.getBar() == bar
-    }
-    
-    @Test
-    public void testSetterNullArg() {
-        
-        assert !(foo.barId)
-        
-        foo.setBar(null)
-        
-        assert !(foo.barId)
-        assert !(foo.getBar())
-
-        foo.setBar(bar)
-        assert foo.barId
-        assert foo.getBar() == bar
-        
-        foo.setBar(null)
-        
-        assert foo.barId
-        assert foo.getBar() == bar
-    }
-    
-    @Test
-    public void testGetterNonExistentId() {
-        foo.setBar(bar)
-        
-        assert foo.barId
-        assert foo.getBar() == bar
-        
-        foo.barId = bar.id+1
-        
-        assert !(foo.getBar())
-    }
-    
-    @Test
-    public void testTransientsListCreated() {
-        assert Foo.transients
-        assert Foo.transients.contains("bar")
-    }
-    
-    @Test
-    public void testTransientsListAddedTo() {
-        Alpha alpha = new Alpha(alpha: "alpha")
-        assert alpha.validate()
-        alpha.save()
-        
-        Beta beta = new Beta(beta: "beta")
-        assert beta.validate()
-        beta.save()
-        
-        assert Alpha.transients
-        assert Alpha.transients.contains("beta")
-        assert Alpha.transients.contains("bar")
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.barId = bar.id
+        then:
+            foo.barId
+            Bar.get(bar.id) == foo.getBar()
     }
 
-    @Test
-    public void testIdFieldWorksWithGormGeneratedId() {
-        Alpha alpha = new Alpha(alpha: "alpha")
-        assert alpha.validate()
-        alpha.save()
+    void "test setter"() {
+        given:
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
 
-        Beta beta = new Beta(beta: "beta")
-        assert beta.validate()
-        beta.save()
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.setBar(bar)
+        then:
+            foo.barId == bar.id
+            foo.getBar() == bar
+    }
 
-        assert Alpha.getField("betaId").type == Long
+    void "test setter with unsaved arg"() {
+        given:
+            Bar bar2 = new Bar(bar: "bar2")
+
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.setBar(bar2)
+        then:
+            !(foo.barId)
+            !(foo.getBar())
+    }
+
+    void "test setter with unsaved arg that was previously set"() {
+        given:
+            Bar bar2 = new Bar(bar: "bar2")
+
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
+
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.setBar(bar)
+            foo.setBar(bar2)
+        then:
+            foo.barId
+            foo.getBar() == bar
+    }
+
+    void "test setter with null arg"() {
+        given:
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.setBar(null)
+        then:
+            !(foo.barId)
+            !(foo.getBar())
+    }
+
+    void "test setter with null arg that was previously set"() {
+        given:
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
+
+            Foo foo = new Foo(foo: "foo1")
+            foo.setBar(bar)
+        when:
+            foo.setBar(null)
+        then:
+            foo.barId
+            foo.getBar() == bar
+    }
+
+    void "test getter return null for non existent id"() {
+        given:
+            Bar bar = new Bar(bar: "bar1")
+            bar.save()
+            Foo foo = new Foo(foo: "foo1")
+        when:
+            foo.barId = bar.id+1
+        then:
+            !(foo.getBar())
+    }
+
+    void "test that transients list created"() {
+        expect:
+            Foo.transients
+            Foo.transients.contains("bar")
+    }
+
+    void "test that transients list was added to"() {
+        given:
+            Alpha alpha = new Alpha(alpha: "alpha")
+            alpha.save()
+
+            Beta beta = new Beta(beta: "beta")
+            beta.save()
+        expect:
+            Alpha.transients
+            Alpha.transients.contains("beta")
+            Alpha.transients.contains("bar")
+    }
+
+    void "test id field works with gorm generated id"() {
+        given:
+            Alpha alpha = new Alpha(alpha: "alpha")
+            alpha.save()
+
+            Beta beta = new Beta(beta: "beta")
+            beta.save()
+        expect:
+            Alpha.getField("betaId").type == Long
     }
 }


### PR DESCRIPTION
I have made some changes to allow this plugin to work with Grails 2.3.2 and above.
#### Changes include:
- upgraded dependencies: hibernate, releases and tomcat (after Grails v2.3 using `:tomcat:$grailsVersion` no longer works, so I have used a hardcoded version instead).
- removed the svn plugin dependency, as this was causing class not found errors. I believe because of the latest releases plugin.
- upgraded the integration and unit tests to use Spock.
- code changes for transformations (see below).
#### Transformation Changes:

Although the test cases all passed in Grails v2.0, I found that when testing v2.3.x, the getter and setter transformations were not being applied and were causing the tests to fail. When I looked into it, I found that the if statement that checks for the existence of the getter and setter methods on the class node was causing the methods not to be added because the methods already existed on the class:

```
        if (parentClass != null && parentClass.getMethod(getMethodName, Parameter.EMPTY_ARRAY) == null) {
            MethodNode methodNode = new MethodNode(
                getMethodName,
                ACC_PUBLIC,
                returnType,
```

 To allow the transforms to still be applied and overwrite any existing method statements, I added an else case that replaces the method's implementation with the new statement:

```
        if (parentClass != null) {

            BlockStatement statement = new BlockStatement(
               [
                   new IfStatement(
                       new BooleanExpression(
                           new BinaryExpression(
                               new VariableExpression(idFieldName),
                               Token.newSymbol("!=", 0, 0),
                               ConstantExpression.NULL
                           )
                       ),
                       createBlockReturnStatement(target),
                       createBlockReturnStatement(ConstantExpression.NULL)
                   )
               ],
               new VariableScope()
            )

            MethodNode methodNode = parentClass.getMethod(getMethodName, Parameter.EMPTY_ARRAY)
            if(methodNode == null) {

                methodNode = new MethodNode(
                    getMethodName,
                    ACC_PUBLIC,
                    returnType,
                    Parameter.EMPTY_ARRAY,
                    [] as ClassNode[],
                    statement
                )
                parentClass.addMethod(methodNode)

            } else {
                methodNode.setCode(statement)
            }
        }
```

Let me know what you think and if any changes are needed.

Thanks for making this plugin.
